### PR TITLE
Fix/tt 449 remove list sorting

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'Back Office',
     'description' => 'Base for back-office extensions',
     'license' => 'GPL-2.0',
-    'version' => '4.0.0',
+    'version' => '4.0.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=22.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -80,6 +80,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.1.1');
         }
 
-        $this->skip('2.1.1', '4.0.0');
+        $this->skip('2.1.1', '4.0.1');
     }
 }

--- a/views/build/grunt/bundle.js
+++ b/views/build/grunt/bundle.js
@@ -32,6 +32,7 @@ module.exports = function(grunt) {
                     bundles : [{
                         name : 'taoBackOffice',
                         default : true,
+                        babel : true,
                         exclude: ['taoBackOffice/lib/vis/vis', 'css!taoBackOffice/lib/vis/vis']
                     }]
                 }

--- a/views/js/controller/list/index.js
+++ b/views/js/controller/list/index.js
@@ -1,81 +1,90 @@
-define(['jquery', 'i18n', 'helpers', 'ui/feedback', 'layout/section', 'css!taoBackOfficeCss/list'], function ($, __, helpers, feedback, section) {
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+define([
+    'jquery',
+    'i18n',
+    'util/url',
+    'ui/feedback',
+    'layout/section',
+    'css!taoBackOfficeCss/list'
+], function ($, __, urlUtil, feedback, section) {
     'use strict';
 
     function _addSquareBtn(title, icon, $listToolBar) {
-        var $btn = $('<button>', { 'class': 'btn-info small lft ' +  'icon-'+ icon, title: __(title) });
+        const $btn = $('<button>', {
+            'class': `btn-info small lft icon-${icon}`,
+            title: __(title) }
+        );
         $listToolBar.append($btn);
         return $btn;
     }
 
     return {
 
-        start: function () {
+        /**
+         * The list controller entrypoint
+         */
+        start() {
 
-            var saveUrl = helpers._url('saveLists', 'Lists', 'taoBackOffice');
-            var delListUrl = helpers._url('removeList', 'Lists', 'taoBackOffice');
-            var delEltUrl = helpers._url('removeListElement', 'Lists', 'taoBackOffice');
+            const saveUrl    = urlUtil.route('saveLists', 'Lists', 'taoBackOffice');
+            const delListUrl = urlUtil.route('removeList', 'Lists', 'taoBackOffice');
+            const delEltUrl  = urlUtil.route('removeListElement', 'Lists', 'taoBackOffice');
 
-            $(".list-edit-btn").click(function () {
-                var $btn = $(this),
-                    uri = $btn.data('uri'),
-                    $listContainer = $("#list-data_" + uri ),
+            $('.list-edit-btn').click(function () {
+                const $btn = $(this);
+                let uri = $btn.data('uri');
+                const $listContainer = $(`#list-data_${uri}`);
+
                 // form must be on the inside rather than on the outside as it has been in 2.6
-                    $listForm     = $listContainer.find('form'),
-                    $listTitleBar = $listContainer.find('.container-title h6'),
-                    $listToolBar  = $listContainer.find('.data-container-footer'),
-                    $listSaveBtn,
-                    $listNewBtn;
+                let $listForm       = $listContainer.find('form');
+                const $listTitleBar = $listContainer.find('.container-title h6');
+                const $listToolBar  = $listContainer.find('.data-container-footer');
+                let $listSaveBtn;
+                let $listNewBtn;
 
                 if (!$listForm.length) {
 
                     $listForm = $('<form>');
                     $listContainer.wrapInner($listForm);
-                    $listContainer.find('form').append('<input type="hidden" name="uri" value="' + uri + '" />');
+                    $listContainer.find('form').append(`<input type='hidden' name='uri' value='${uri}' />`);
 
-                    var $labelEdit = $("<input type='text' name='label' value=''/>").val($listTitleBar.text());
+                    const $labelEdit = $(`<input type='text' name='label' value=''/>`).val($listTitleBar.text());
                     $listTitleBar.html($labelEdit);
 
                     if ($listContainer.find('.list-element').length) {
                         $listContainer.find('.list-element').replaceWith(function () {
-                            return $("<input type='text' name='" + $(this).attr('id') + "' value='' />").val($(this).text());
+                            return $(`<input type='text' name='${$(this).attr('id')}' value='' />`).val($(this).text());
                         });
                     }
 
-                    var elementList = $listContainer.find('ol');
+                    const elementList = $listContainer.find('ol');
                     elementList.addClass('sortable-list');
-                    elementList.find('li').prepend('<span class="icon-grip" ></span>');
-                    elementList.find('li').append('<span class="icon-checkbox-crossed list-element-delete-btn"></span>');
+                    elementList.find('li').append(`<span class='icon-checkbox-crossed list-element-delete-btn'></span>`);
 
-                    elementList.sortable({
-                        axis: 'y',
-                        opacity: 0.6,
-                        placeholder: 'ui-state-error',
-                        tolerance: 'pointer',
-                        update: function (event, ui) {
-                            var map = {};
-                            $.each($(this).sortable('toArray'), function (index, id) {
-                                map[id] = 'list-element_' + (index + 1);
-                            });
-                            $(this).find('li').each(function () {
-                                var id = $(this).attr('id');
-                                if (map[id]) {
-                                    $(this).attr('id', map[id]);
-                                    var newName = $(this).find('input').attr('name').replace(id, map[id]);
-                                    $(this).find('input').attr('name', newName);
-                                }
-                            });
-                        }
-                    });
-
-                    $listSaveBtn = _addSquareBtn('Save element', 'save', $listToolBar);
+                    $listSaveBtn = _addSquareBtn(__('Save element'), 'save', $listToolBar);
                     $listSaveBtn.on('click', function () {
                         $.postJson(
                             saveUrl,
                             $(this).closest('form').serializeArray(),
-                            function (response) {
+                            response => {
                                 if (response.saved) {
                                     feedback().success(__('List saved'));
-                                    section.get('taoBo_list').loadContentBlock(helpers._url('index', 'Lists', 'taoBackOffice'));
+                                    section.get('taoBo_list').loadContentBlock(urlUtil.route('index', 'Lists', 'taoBackOffice'));
                                 }else{
                                     feedback().error(__('List not saved'));
                                 }
@@ -87,29 +96,27 @@ define(['jquery', 'i18n', 'helpers', 'ui/feedback', 'layout/section', 'css!taoBa
                     $listNewBtn = _addSquareBtn('New element', 'add', $listToolBar);
                     $listNewBtn.click(function () {
                         var level = $(this).closest('form').find('ol').children().length + 1;
-                        $(this).closest('form').find('ol').append(
-                            "<li id='list-element_" + level + "'>\n" +
-                            "<span class='icon-grip' ></span>\n" +
-                            "<input type='text' name='list-element_" + level + "_' />\n" +
-                            "<span class='icon-checkbox-crossed list-element-delete-btn' ></span>\n" +
-                            "</li>");
+                        $(this).closest('form')
+                            .find('ol')
+                            .append(`<li id='list-element_${level}'>
+                                <input type='text' name='list-element_${level}_' />
+                                <span class='icon-checkbox-crossed list-element-delete-btn' ></span>
+                            </li>`);
                         return false;
                     });
                 }
 
                 $listContainer.on('click', '.list-element-delete-btn', function () {
-                    var $btn = $(this),
-                        uri = $btn.data('uri'),
-                        $element = $(this).parent(),
-                        $input = $element.find('input:text');
+                    const $element = $(this).parent();
+                    const $input   = $element.find('input:text');
 
-                    if ($input.val() === '' || confirm(__("Please confirm you want to delete this list element."))) {
-                        uri = $input.attr('name').replace(/^list\-element\_([1-9]*)\_/, '');
-                        if (uri) {
+                    if ($input.val() === '' || window.confirm(__('Please confirm you want to delete this list element.'))) {
+                        let eltUri = $input.attr('name').replace(/^list\-element\_([1-9]*)\_/, '');
+                        if (eltUri) {
                             $.postJson(
                                 delEltUrl,
-                                {uri: uri},
-                                function (response) {
+                                { uri : eltUri },
+                                response => {
                                     if (response.deleted) {
                                         $element.remove();
                                         feedback().success(__('Element deleted'));
@@ -127,18 +134,18 @@ define(['jquery', 'i18n', 'helpers', 'ui/feedback', 'layout/section', 'css!taoBa
             });
 
             $('.list-delete-btn').click(function () {
-                if (confirm(__("Please confirm you want to delete this list. This operation cannot be undone."))) {
-                    var $btn = $(this),
-                        uri = $btn.data('uri'),
-                        $list = $(this).parents(".data-container");
+                if (window.confirm(__('Please confirm you want to delete this list. This operation cannot be undone.'))) {
+                    const $btn  = $(this);
+                    const uri   = $btn.data('uri');
+                    const $list = $btn.parents('.data-container');
                     $.postJson(
                         delListUrl,
-                        {uri: uri},
-                        function (response) {
+                        { uri },
+                        response => {
                             if (response.deleted) {
                                 feedback().success(__('List deleted'));
                                 $list.remove();
-                            }else{
+                            } else {
                                 feedback().error(__('List not deleted'));
                             }
                         }

--- a/views/js/controller/list/index.js
+++ b/views/js/controller/list/index.js
@@ -25,9 +25,9 @@ define([
 ], function ($, __, urlUtil, feedback, section) {
     'use strict';
 
-    function _addSquareBtn(title, icon, $listToolBar) {
+    function _addSquareBtn(title, icon, $listToolBar, position='lft') {
         const $btn = $('<button>', {
-            'class': `btn-info small lft icon-${icon}`,
+            'class': `btn-info small ${position} icon-${icon}`,
             title: __(title) }
         );
         $listToolBar.append($btn);
@@ -57,6 +57,8 @@ define([
                 let $listSaveBtn;
                 let $listNewBtn;
 
+                $btn.addClass('hidden');
+
                 if (!$listForm.length) {
 
                     $listForm = $('<form>');
@@ -76,7 +78,7 @@ define([
                     elementList.addClass('sortable-list');
                     elementList.find('li').append(`<span class='icon-checkbox-crossed list-element-delete-btn'></span>`);
 
-                    $listSaveBtn = _addSquareBtn(__('Save element'), 'save', $listToolBar);
+                    $listSaveBtn = _addSquareBtn(__('Save list'), 'save', $listToolBar, 'rgt');
                     $listSaveBtn.on('click', function () {
                         $.postJson(
                             saveUrl,

--- a/views/js/controller/list/index.js
+++ b/views/js/controller/list/index.js
@@ -113,7 +113,7 @@ define([
                     const $input   = $element.find('input:text');
 
                     if ($input.val() === '' || window.confirm(__('Please confirm you want to delete this list element.'))) {
-                        let eltUri = $input.attr('name').replace(/^list\-element\_([1-9]*)\_/, '');
+                        let eltUri = $input.attr('name').replace(/^list\-element\_([0-9]*)\_/, '');
                         if (eltUri) {
                             $.postJson(
                                 delEltUrl,

--- a/views/js/controller/list/index.js
+++ b/views/js/controller/list/index.js
@@ -26,7 +26,7 @@ define([
 ], function ($, __, urlUtil, feedback, dialogConfirm, section) {
     'use strict';
 
-    function _addSquareBtn(title, icon, $listToolBar, position='lft') {
+    function addSquareBtn(title, icon, $listToolBar, position='lft') {
         const $btn = $('<button>', {
             'class': `btn-info small ${position} icon-${icon}`,
             title: __(title) }
@@ -51,7 +51,6 @@ define([
                 let uri = $btn.data('uri');
                 const $listContainer = $(`#list-data_${uri}`);
 
-                // form must be on the inside rather than on the outside as it has been in 2.6
                 let $listForm       = $listContainer.find('form');
                 const $listTitleBar = $listContainer.find('.container-title h6');
                 const $listToolBar  = $listContainer.find('.data-container-footer');
@@ -79,7 +78,7 @@ define([
                     elementList.addClass('sortable-list');
                     elementList.find('li').append(`<span class='icon-checkbox-crossed list-element-delete-btn'></span>`);
 
-                    $listSaveBtn = _addSquareBtn(__('Save list'), 'save', $listToolBar, 'rgt');
+                    $listSaveBtn = addSquareBtn(__('Save list'), 'save', $listToolBar, 'rgt');
                     $listSaveBtn.on('click', function () {
                         $.postJson(
                             saveUrl,
@@ -96,7 +95,7 @@ define([
                         return false;
                     });
 
-                    $listNewBtn = _addSquareBtn('New element', 'add', $listToolBar);
+                    $listNewBtn = addSquareBtn('New element', 'add', $listToolBar);
                     $listNewBtn.click(function () {
                         var level = $(this).closest('form').find('ol').children().length + 1;
                         $(this).closest('form')


### PR DESCRIPTION
This controller in taoBackoffice did not declare it's dependency to jqueryui, so it was still containing references to jqueryui.sortable after the removal of it.

This PR fix the code style of the controller and remove the sorting of the list.
The controller code still doesn't comply with the guidelines (inline HTML and CSS, no separation of concerns, not testable, etc.) but at least works as expected.