### PR TITLE
fix: avoid consider duplicated empty URIs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis" : ">=14.0.0",
-        "oat-sa/tao-core" : ">=48.74.0"
+        "oat-sa/tao-core" : ">=48.84.1"
     },
     "autoload" : {
         "psr-4" : {

--- a/controller/Lists.php
+++ b/controller/Lists.php
@@ -330,7 +330,7 @@ class Lists extends tao_actions_CommonModule
             $newUriValue = trim($payload["uri_$key"] ?? '');
             $element = $elements->extractValueByUri($uri);
 
-            if ($element === null) {
+            if ($element === null || empty($uri)) {
                 $elements->addValue(new Value(null, $newUriValue, $value));
 
                 continue;


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/ADF-915

## Description

We need to put back the previous behavior and ignore duplications in case on empty URIs (which means, new records).

## PRs

- [ ] https://github.com/oat-sa/tao-core/pull/3358