### PR TITLE
fix: Replace grant for the whole Lists controller with one just for getListElements

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -40,7 +40,7 @@ return [
         ],
         [
             AccessRule::GRANT,
-            'http://www.tao.lu/Ontologies/TAO.rdf#PropertyManagerRole',
+            TaoRoles::PROPERTY_MANAGER,
             ['act' => Lists::class .'@getListElements'],
         ],
         [

--- a/manifest.php
+++ b/manifest.php
@@ -37,6 +37,7 @@ return [
             'http://www.tao.lu/Ontologies/generis.rdf#taoBackOfficeManager',
             ['ext' => 'taoBackOffice'],
         ],
+        // @todo Check this one with a fresh installation
         [
             AccessRule::GRANT,
             'http://www.tao.lu/Ontologies/TAO.rdf#PropertyManagerRole',

--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,6 @@ return [
             'http://www.tao.lu/Ontologies/generis.rdf#taoBackOfficeManager',
             ['ext' => 'taoBackOffice'],
         ],
-        // @todo Check this one with a fresh installation
         [
             AccessRule::GRANT,
             'http://www.tao.lu/Ontologies/TAO.rdf#PropertyManagerRole',

--- a/manifest.php
+++ b/manifest.php
@@ -1,6 +1,7 @@
 <?php
 
 use oat\tao\model\user\TaoRoles;
+use oat\taoBackOffice\controller\Lists;
 use oat\taoBackOffice\controller\Redirector;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\taoBackOffice\model\lists\ListServiceProvider;
@@ -41,7 +42,7 @@ return [
         [
             AccessRule::GRANT,
             'http://www.tao.lu/Ontologies/TAO.rdf#PropertyManagerRole',
-            ['controller' => 'oat\taoBackOffice\controller\Lists'],
+            ['act' => Lists::class .'@getListElements'],
         ],
         [
             AccessRule::GRANT,

--- a/migrations/Version202203021737164728_taoBackOffice.php
+++ b/migrations/Version202203021737164728_taoBackOffice.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoBackOffice\migrations;
+
+use common_report_Report as Report;
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\model\user\TaoRoles;
+use oat\tao\model\accessControl\func\AclProxy;
+use oat\tao\model\accessControl\func\AccessRule;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoBackOffice\controller\Lists;
+use oat\taoItems\model\user\TaoItemsRoles;
+
+final class Version202203021737164728_taoBackOffice extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Grant access to getListElements for ' . TaoRoles::PROPERTY_MANAGER;
+    }
+
+    public function up(Schema $schema): void
+    {
+        AclProxy::revokeRule($this->getOldRule());
+        AclProxy::applyRule($this->getNewRule());
+
+        $this->addReport(Report::createInfo(
+            'Access to taoBackOffice has been updated for '.
+            TaoRoles::PROPERTY_MANAGER
+        ));
+    }
+
+    public function down(Schema $schema): void
+    {
+        AclProxy::revokeRule($this->getNewRule());
+        AclProxy::applyRule($this->getOldRule());
+
+        $this->addReport(Report::createInfo(
+            'Access to taoBackOffice has been updated for '.
+            TaoRoles::PROPERTY_MANAGER
+        ));
+    }
+
+    private function getNewRule(): AccessRule
+    {
+        return new AccessRule(
+            AccessRule::GRANT,
+            TaoRoles::PROPERTY_MANAGER,
+            [
+                'act' => Lists::class .'@getListElements',
+            ]
+        );
+    }
+
+    private function getOldRule(): AccessRule
+    {
+        return new AccessRule(
+            AccessRule::GRANT,
+            TaoRoles::PROPERTY_MANAGER,
+            [
+                'controller' => Lists::class,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
**Associated Jira issue:** [AUT-1927](https://oat-sa.atlassian.net/browse/AUT-1927)

This PR replaces the grant for `PropertyManagers` for accessing the whole BackOffice List controller and grants access just to the `getListElements` endpoint, which is enough for Manage Schema pages.

- [x] Verify the migration fixes the issue for a existing environment
- [x] Verify the fix in the manifest works on a fresh installation