### PR TITLE
fix: when env feature flag is not defined fallback to defined ref property

### DIFF
--- a/migrations/Version202306141009333246_taoBackOffice.php
+++ b/migrations/Version202306141009333246_taoBackOffice.php
@@ -12,7 +12,7 @@ use oat\taoBackOffice\scripts\install\MapPasswordControlFeatureFlag;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version202306141009333245_taoBackOffice extends AbstractMigration
+final class Version202306141009333246_taoBackOffice extends AbstractMigration
 {
 
     public function getDescription(): string

--- a/scripts/install/MapPasswordControlFeatureFlag.php
+++ b/scripts/install/MapPasswordControlFeatureFlag.php
@@ -22,6 +22,9 @@ declare(strict_types=1);
 
 namespace oat\taoBackOffice\scripts\install;
 
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
+use oat\generis\model\data\Ontology;
 use oat\oatbox\extension\InstallAction;
 use oat\tao\model\menu\SectionVisibilityFilter;
 
@@ -37,6 +40,16 @@ class MapPasswordControlFeatureFlag extends InstallAction
             SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS,
             $featureFlagSections
         );
+        /** @var core_kernel_classes_Resource $ffResource */
+        $ffResource = $this->getServiceManager()
+            ->get(Ontology::SERVICE_ID)
+            ->getResource('http://www.tao.lu/Ontologies/TAO.rdf#featureFlags');
+
+        $ffProperty = new core_kernel_classes_Property(
+            'http://www.tao.lu/Ontologies/TAO.rdf#featureFlags_FEATURE_FLAG_PASSWORD_CHANGE_AVAILABLE'
+        );
+
+        $ffResource->setPropertyValue($ffProperty, true);
         $this->getServiceManager()->register(SectionVisibilityFilter::SERVICE_ID, $sectionVisibilityFilter);
     }
 }


### PR DESCRIPTION
In MapPasswordControlFeatureFlag I will define fallback for instances where the feature flag is not enabled to true so the default behaviour would be that section FEATURE_FLAG_HELP_SECTION will be visible by default. 