### PR TITLE
fix: tao-core version updated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis" : ">=15.22",
-        "oat-sa/tao-core" : ">=50.24.6"
+        "oat-sa/tao-core" : ">=53.3.2"
     },
     "autoload" : {
         "psr-4" : {


### PR DESCRIPTION
Updated tao-core version to >=53.3.2 in order to fix missing constants.