### PR TITLE
fix: align default tree action weight for quick wins sorting

### DIFF
--- a/model/menuStructure/Action.php
+++ b/model/menuStructure/Action.php
@@ -61,7 +61,7 @@ interface Action
      * Default value of action weight
      * @var int
      */
-    public const WEIGHT_DEFAULT = 0;
+    public const WEIGHT_DEFAULT = 14;
 
     /**
      * @return string Identifier of action


### PR DESCRIPTION
## Summary
- align the global default menu action weight with the expected tree action order under Quick Wins sorting
- keep existing explicit weights untouched and let actions without explicit weights fall after prioritized tree actions
- preserve runtime order for Items and Tests where Access control should no longer be rendered first

## Validation
- cleared cache with `rm -Rf data/generis/cache/*`
- verified runtime sorted order via TAO bootstrap script and browser checks in Items/Tests/Deliveries sections


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted default action priority to improve menu item ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oat-sa/extension-tao-backoffice/pull/208)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->